### PR TITLE
Qhull server option

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
 	<title>4D Geometry Viewer</title>
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="src/css/index.css">
+	<!-- For making POST requests --> 
+	<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 	<!-- For parsing mathematical expressions. Used by the gui -->
 	<script src="src/lib/parser.js"></script>
 	<script src="src/lib/glsl_parser.js"></script>

--- a/src/4d.js
+++ b/src/4d.js
@@ -20,6 +20,7 @@ var Mode4D = (function (scope) {
 		this.rightMesh = null;
 
 		this.gridIsVisible = true;
+		this.useQHull = true;
 	}
 
 	// Creates the scene and everything
@@ -171,6 +172,11 @@ var Mode4D = (function (scope) {
 	}
 
 	Mode4D.prototype.callbacks = {
+		'qhull': function(self,val) {
+			self.useQHull = val
+			self.cleanupLeftMesh()
+			self.initConvexHull()
+		},
 		'axis':function(self,val) {
 			if(self.current_mode == "cartesian") {
 				self.cleanupLeftMesh();
@@ -312,6 +318,7 @@ var Mode4D = (function (scope) {
 
 	Mode4D.prototype.initConvexHull = function(){
 		var pointsRaw = this.util.ParseConvexPoints(this.gui.params.points);
+		if(pointsRaw.length == 0) return;
 		var projectingColor = new THREE.Color(this.gui.colors.projections);
 
 		// Convert the points into Vector3 objects:
@@ -323,46 +330,84 @@ var Mode4D = (function (scope) {
 			points.push(newPoint);
 		}
 	
+		var that = this;
+		function finishShape(facets){
+			// Just construct the wireframe here 
+			var final_points = [];
+			var final_edges = [];
 			
-		var CHull4D = new QuickHull4D();
+			for(var i=0;i<facets.length;i++){
+				var f = facets[i];
+				for(var j=0;j<f.edges.length;j++){
+					final_edges.push(f.edges[j][0],f.edges[j][1]);
+				}
+				for(var j=0;j<f.vertices.length;j++){
+					final_points.push(f.vertices[j]);
+				}
+			}
 
-		var facets = CHull4D.ComputeHull(points);
-		// Just construct the wireframe here 
-		var final_points = [];
-		var final_edges = [];
-		
-		for(var i=0;i<facets.length;i++){
-			var f = facets[i];
-			for(var j=0;j<f.edges.length;j++){
-				final_edges.push(f.edges[j][0],f.edges[j][1]);
-			}
-			for(var j=0;j<f.vertices.length;j++){
-				final_points.push(f.vertices[j]);
-			}
+			var container = new THREE.Object3D();
+
+			var mesh = that.projector.Wireframe4D(final_points,final_edges,projectingColor);
+			that.leftMesh = container;
+			container.uniforms = mesh.uniforms;
+			container.baseVectors = mesh.baseVectors;
+			container.updateMatrixFromRotors = mesh.updateMatrixFromRotors;
+			container.add(mesh);
+			
+			that.leftMesh.rawFacets = facets;
+
+			// Create solid facets too 
+			// for(var i=0;i<facets.length;i++){
+			// 	var F = facets[i];
+			// 	var geometry = new THREE.ConvexBufferHyperGeometry(F.vertices);
+			// 	var material = new THREE.HyperMaterial({color:projectingColor});
+			// 	var mesh = new THREE.Mesh(geometry,material);
+			// 	container.add(mesh);
+			// }
+
+			that.leftScene.add(that.leftMesh);
+			that.ComputeSlicesCPU();
 		}
 
-		var container = new THREE.Object3D();
+		if(this.useQHull){
+			var params = new URLSearchParams();
+			params.append('points', JSON.stringify(points));
+			axios.post('https://omarshehata.me/qhull/', params)
+			.then(function (response) {
+				var rawFacets = response.data;
+				var facets = []
+				// Construct structured facets out of Qhull's raw output 
+				for(var i=0;i<rawFacets.length;i++){
+					var rawF = rawFacets[i]
+					var vertices = []
+					for(var j=0;j<rawF.length;j++){
+						var index = rawF[j]
+						var point = points[index]
+						vertices.push(point)
+					}
+					var edges = []
+					edges.push([vertices[0],vertices[1]])
+					edges.push([vertices[1],vertices[2]])
+					edges.push([vertices[2],vertices[3]])
+					edges.push([vertices[3],vertices[0]])
 
-		var mesh = this.projector.Wireframe4D(final_points,final_edges,projectingColor);
-		this.leftMesh = container;
-		container.uniforms = mesh.uniforms;
-		container.baseVectors = mesh.baseVectors;
-		container.updateMatrixFromRotors = mesh.updateMatrixFromRotors;
-		container.add(mesh);
+					facets.push({edges:edges,vertices:vertices})
+				}
+				finishShape(facets)
+			})
+			.catch(function (error) {
+				// Clear shape 
+				console.log(error)
+				that.cleanupLeftMesh();
+			});
+		} else {
+			var CHull4D = new QuickHull4D();
+			var facets = CHull4D.ComputeHull(points);
+			finishShape(facets)
+		}
 		
-		this.leftMesh.rawFacets = facets;
-
-		// Create solid facets too 
-		// for(var i=0;i<facets.length;i++){
-		// 	var F = facets[i];
-		// 	var geometry = new THREE.ConvexBufferHyperGeometry(F.vertices);
-		// 	var material = new THREE.HyperMaterial({color:projectingColor});
-		// 	var mesh = new THREE.Mesh(geometry,material);
-		// 	container.add(mesh);
-		// }
-
-		this.leftScene.add(this.leftMesh);
-		this.ComputeSlicesCPU();
+		
 	}
 
 

--- a/src/4d.js
+++ b/src/4d.js
@@ -371,10 +371,11 @@ var Mode4D = (function (scope) {
 		}
 
 		if(this.useQHull){
-			var params = new URLSearchParams();
-			params.append('points', JSON.stringify(points));
-			axios.post('https://omarshehata.me/qhull/', params)
+			axios.get('https://omarshehata.me/qhull/?points=' + JSON.stringify(points))
 			.then(function (response) {
+				if(response.data == 'No points given'){
+					throw new Error('Qhull server returned "no points given".');
+				}
 				var rawFacets = response.data;
 				var facets = []
 				// Construct structured facets out of Qhull's raw output 

--- a/src/util/gui.js
+++ b/src/util/gui.js
@@ -110,6 +110,7 @@ var GUI = (function (scope) {
 			'thickness':'medium',
 			'show left view': true,
 			'show right view': true,
+			'qhull':true
 		};
 		this.gui = null;
 		this.mode = "";
@@ -143,7 +144,7 @@ var GUI = (function (scope) {
 		// 4D defaults
 		this.defaults['4D'] = {
 			'equation':'x^2+y^2+z^2+w^2 = 10',
-			'points':'',
+			'points':'(-5,-5,-5,-5),(5,-5,-5,-5),(-5,5,-5,-5),(5,5,-5,-5),(-5,-5,5,-5),(5,-5,5,-5),(-5,5,5,-5),(5,5,5,-5),(-5,-5,-5,5),(5,-5,-5,5),(-5,5,-5,5),(5,5,-5,5),(-5,-5,5,5),(5,-5,5,5),(-5,5,5,5),(5,5,5,5)' , // Small tesseract
 			'resolution':'low',
 			'param_eq_x':'',
 			'param_eq_y':'',
@@ -154,6 +155,7 @@ var GUI = (function (scope) {
 			'param_c':'0 < c < 1',
 			'param_d':'0 < d < 1',
 			'axis':'W',
+			'qhull': true
 		}
 
 		this.mode_obj = null;
@@ -244,6 +246,8 @@ var GUI = (function (scope) {
 		}
 
 
+
+
 		// Turn all sliders orange 
 		var sliders = document.querySelectorAll(".slider-fg")
 		for(var i=0;i<sliders.length;i++){
@@ -278,6 +282,8 @@ var GUI = (function (scope) {
 			});
 			arr.push(res);
 		}
+
+		
 
 
 		this.builtin_arr_cartesian = this.constructExampleItems(this.mode,'cartesian');
@@ -369,6 +375,13 @@ var GUI = (function (scope) {
 			if(callbacks['points']) callbacks['points'](mode_obj,val);
 		}).listen();
 		arr.push(points);
+
+		if(this.mode == '4D'){
+			var useQHull = this.shapeProperties.add(this.params, 'qhull').name("Use QHull Server").listen().onChange(function(val){
+				if(callbacks['qhull']) callbacks['qhull'](mode_obj,val);
+			});
+			arr.push(useQHull);
+		}
 
 		this.builtin_arr_convex = this.constructExampleItems(this.mode,'convex-hull');
 


### PR DESCRIPTION
Adds a "Use Qhull Server" checkbox. While our built in implementation works, it's slow, and doesn't work for every scenario. This will serve as a backup, and also as a way to check our results (you can click on the checkbox to easily toggle between the two algorithms to see the difference).

The server is running on my personal website, so if that ever goes down, unchecking it will run the built in one, so no worries there. 